### PR TITLE
fix: replace bare except with Exception in WebSocket connection fallback

### DIFF
--- a/eval_utils/policy_client.py
+++ b/eval_utils/policy_client.py
@@ -48,7 +48,7 @@ class WebsocketClientPolicy(BasePolicy):
             )
             metadata = msgpack_numpy.unpackb(conn.recv())
             return conn, metadata
-        except:
+        except Exception:
             logging.info("Connection to server with ws:// failed. Trying wss:// ...")
             
         self._uri = "wss://" + self._uri.split("//")[1]


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `eval_utils/policy_client.py` for the ws:// → wss:// fallback. Bare except catches `SystemExit`/`KeyboardInterrupt`, preventing clean shutdown.