### PR TITLE
Fix Sim Eval Error

### DIFF
--- a/eval_utils/run_sim_eval.py
+++ b/eval_utils/run_sim_eval.py
@@ -88,7 +88,8 @@ class DreamZeroJointPosClient(InferenceClient):
             for k, v in request_data.items():
                 print(f"{k}: {v.shape if not isinstance(v, str) else v}")
             
-            actions = self.client.infer(request_data)
+            result = self.client.infer(request_data)
+            actions = result["actions"] if isinstance(result, dict) else result
             assert len(actions.shape) == 2, f"Expected 2D array, got shape {actions.shape}"
             assert actions.shape[-1] == 8, f"Expected 8 action dimensions (7 joints + 1 gripper), got {actions.shape[-1]}"
             self.pred_action_chunk = actions


### PR DESCRIPTION
This PR is used to fix: https://github.com/dreamzero0/dreamzero/issues/27

# Fix `run_sim_eval.py` crash: extract actions from server response dict

## Summary

- `eval_utils/run_sim_eval.py` crashes on the first inference call with `AttributeError: 'dict' object has no attribute 'shape'`
- Root cause: `WebsocketClientPolicy.infer()` returns a deserialized dict (`{"actions": np.ndarray}`), but `run_sim_eval.py` treats the return value as a raw numpy array
- Fix: extract the `"actions"` key from the response dict before using it

## Details

The server (`socket_test_optimized_AR.py`, line 662) packs the inference result as a dict:

```python
action_chunk_dict = batch_to_dict(action_chunk_dict)
await websocket.send(packer.pack(action_chunk_dict))
```

The client (`policy_client.py`) deserializes it via `msgpack_numpy.unpackb(response)`, returning:

```python
{"actions": np.ndarray(shape=(24, 8), dtype=float32)}
```

But `run_sim_eval.py` directly calls `.shape` on this dict, which fails.

## Changes

```diff
-            actions = self.client.infer(request_data)
+            result = self.client.infer(request_data)
+            actions = result["actions"] if isinstance(result, dict) else result
```

## Tests

- [x] Verified server response format: `{"actions": np.array(shape=(24, 8), dtype=float32)}`
- [x] Successfully ran 5 episodes to completion with the fix applied, all output MP4 videos saved correctly
- [x] Tested on H100 with Isaac Sim 5.0 in headless mode
