### PR TITLE
Fix: inject LoRA adapters before loading LoRA weights in from_pretrained

### DIFF
--- a/groot/vla/model/dreamzero/base_vla.py
+++ b/groot/vla/model/dreamzero/base_vla.py
@@ -324,6 +324,10 @@ class VLA(PreTrainedModel):
             )
 
         if lora_weights_path is not None:
+            # Inject LoRA adapters first (base weights are already loaded with correct key paths)
+            if hasattr(model, 'action_head') and hasattr(model.action_head, 'inject_lora_after_loading'):
+                print("Injecting LoRA adapters before loading LoRA weights")
+                model.action_head.inject_lora_after_loading()
             print(f"Loading LoRA weights from: {lora_weights_path}")
             model.load_lora_weight(lora_weights_path)
         else:


### PR DESCRIPTION
## Summary

- **Bug**: When `defer_lora_injection=True`, `VLA.from_pretrained()` (inference path) calls `load_lora_weight()` without first injecting LoRA adapters. The LoRA weight keys (`lora_A`, `lora_B`) have no matching parameters, so loaded weights are silently dropped.
- **Root cause**: The `else` branch correctly calls `inject_lora_after_loading()`, but the `if lora_weights_path is not None` branch does not.
- **Fix**: Call `inject_lora_after_loading()` before `load_lora_weight()` when a LoRA weights path is provided.

Note: The training path in `base.py` (`create_model`) is not affected — it already calls `inject_lora_after_loading()` unconditionally after loading pretrained weights.

## Affected code

`groot/vla/model/dreamzero/base_vla.py`, `VLA.from_pretrained()` method.

**Before (buggy):**
\`\`\`python
if lora_weights_path is not None:
    model.load_lora_weight(lora_weights_path)  # LoRA adapters don't exist yet!
else:
    if ... defer_lora_injection:
        model.action_head.inject_lora_after_loading()
\`\`\`

**After (fixed):**
\`\`\`python
if lora_weights_path is not None:
    if hasattr(model.action_head, 'inject_lora_after_loading'):
        model.action_head.inject_lora_after_loading()  # Create adapters first
    model.load_lora_weight(lora_weights_path)           # Then load weights
else:
    if ... defer_lora_injection:
        model.action_head.inject_lora_after_loading()
\`\`\`

## Test plan

- [ ] Load a LoRA-finetuned checkpoint with `defer_lora_injection=True` via `VLA.from_pretrained()` and verify LoRA weights are correctly applied
- [ ] Verify inference outputs differ from base model (confirming LoRA weights took effect)