### PR TITLE
Fix prompt padding mask per sample

### DIFF
--- a/groot/vla/model/dreamzero/action_head/wan_flow_matching_action_tf.py
+++ b/groot/vla/model/dreamzero/action_head/wan_flow_matching_action_tf.py
@@ -544,7 +544,7 @@ class WANPolicyHead(ActionHead):
         prompt_emb = self.text_encoder(input_ids, attention_mask)
         prompt_emb = prompt_emb.clone().to(dtype=torch.bfloat16)
         for i, v in enumerate(seq_lens):
-            prompt_emb[:, v:] = 0
+            prompt_emb[i, v:] = 0
         return prompt_emb
 
     def _ensure_vae_on_device(self, ref_tensor):


### PR DESCRIPTION
## Summary
- fix prompt embedding padding cleanup to zero only the current sample's padded tokens
- prevent one sample's sequence length from masking later prompt tokens for every batch item

## Testing
- python -m compileall -q groot/vla/model/dreamzero/action_head/wan_flow_matching_action_tf.py